### PR TITLE
refactor: v2 auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 keys
 dist
 .env
+dump.rdb
+prisma/dev.db

--- a/libs/guard/src/auth.guard.ts
+++ b/libs/guard/src/auth.guard.ts
@@ -31,11 +31,11 @@ export class AuthGuard implements CanActivate {
       context.getHandler(),
       context.getClass(),
     ]);
+    const http = context.switchToHttp();
+    const req: AuthReq = http.getRequest();
     if (!requiredToken) {
       return true;
     }
-    const http = context.switchToHttp();
-    const req: AuthReq = http.getRequest();
     const token = this.getToken(req);
     if (!token) {
       throw new HttpException('未登录', HttpStatus.UNAUTHORIZED);
@@ -50,7 +50,7 @@ export class AuthGuard implements CanActivate {
       throw new HttpException(msg, HttpStatus.UNAUTHORIZED);
     }
     const { id } = this.jwt.decode<AccessTokenPayload>(token);
-    const activeState = req.url.startsWith('/v2')
+    const activeState = req.headers['x-auth-version'] === '2'
       ? await this.authv2.active(id).then(Boolean)
       : await this.auth.active(BigInt(id)).then(Boolean);
     if (!activeState) {

--- a/src/auth/v2/auth.controller.ts
+++ b/src/auth/v2/auth.controller.ts
@@ -16,7 +16,7 @@ import { Request, Response } from 'express';
 import { LoginDto } from '../dto/login.dto';
 import { RefreshToken } from '../dto/refresh-token';
 import { JwtService } from '@app/jwt';
-import { findLast, isNil } from 'ramda';
+import { isNil } from 'ramda';
 import { Auth } from '@app/decorator';
 import { Token } from '../token.decorator';
 
@@ -50,22 +50,23 @@ export class V2Auth {
       throw new HttpException('session-state 过期', HttpStatus.UNAUTHORIZED);
     }
     res.status(HttpStatus.OK);
-    return this.authService.readTokenPairById(id);
+    const code = this.authService.createCode();
+    await this.authService.invokeCode(code, id);
+    return { code };
   }
 
   @Get('/token')
   async getToken(
     @Query('code') code: string,
     @Res({ passthrough: true }) res: Response,
-    @Req() req: Request,
   ) {
-    if (req.cookies['session-state']) {
-      res.status(HttpStatus.OK);
-      return this.getTokenBySession(req, res);
-    }
     const id = await this.authService.readIdByCode(code);
     if (!id) {
       throw new HttpException('授权码过期', HttpStatus.BAD_REQUEST);
+    }
+    const pair = await this.authService.readTokenPairById(id);
+    if (pair) {
+      return pair;
     }
     const accessToken = await this.authService.createAccessToken(id);
     const refreshToken = await this.authService.createRefreshToken(id);
@@ -153,6 +154,7 @@ export class V2Auth {
       if (!id) {
         res.clearCookie('session-state');
         res.status(HttpStatus.OK);
+        return;
       }
       const session = await this.authService.readSessionById(id);
       if (session) {
@@ -167,8 +169,7 @@ export class V2Auth {
         await this.authService.invokeToken(id, refreshToken.token, 'refresh');
       }
       res.status(HttpStatus.OK);
-    } catch {
-    } finally {
+    } catch {} finally {
       res.clearCookie('session-state');
       res.status(HttpStatus.OK);
     }

--- a/src/auth/v2/auth.controller.ts
+++ b/src/auth/v2/auth.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   HttpException,
   HttpStatus,
+  Logger,
   Post,
   Query,
   Req,
@@ -22,6 +23,7 @@ import { Token } from '../token.decorator';
 
 @Controller('/v2/auth')
 export class V2Auth {
+  private logger: Logger = new Logger(V2Auth.name);
   constructor(
     private authService: V2AuthService,
     private clientService: ClientService,
@@ -169,7 +171,9 @@ export class V2Auth {
         await this.authService.invokeToken(id, refreshToken.token, 'refresh');
       }
       res.status(HttpStatus.OK);
-    } catch {} finally {
+    } catch (err) {
+      this.logger.error(err.message, err.stack);
+    } finally {
       res.clearCookie('session-state');
       res.status(HttpStatus.OK);
     }

--- a/src/auth/v2/auth.controller.ts
+++ b/src/auth/v2/auth.controller.ts
@@ -16,7 +16,7 @@ import { Request, Response } from 'express';
 import { LoginDto } from '../dto/login.dto';
 import { RefreshToken } from '../dto/refresh-token';
 import { JwtService } from '@app/jwt';
-import { isNil } from 'ramda';
+import { isNil, isNotNil } from 'ramda';
 import { Auth } from '@app/decorator';
 import { Token } from '../token.decorator';
 
@@ -65,7 +65,7 @@ export class V2Auth {
       throw new HttpException('授权码过期', HttpStatus.BAD_REQUEST);
     }
     const pair = await this.authService.readTokenPairById(id);
-    if (pair) {
+    if (isNotNil(pair.accessToken.token) && isNotNil(pair.refreshToken.token)) {
       return pair;
     }
     const accessToken = await this.authService.createAccessToken(id);
@@ -163,10 +163,10 @@ export class V2Auth {
       const { accessToken, refreshToken } =
         await this.authService.readTokenPairById(id);
       if (accessToken.token) {
-        await this.authService.invokeToken(id, accessToken.token, 'access');
+        await this.authService.revokeToken(accessToken.token, 'access');
       }
       if (refreshToken.token) {
-        await this.authService.invokeToken(id, refreshToken.token, 'refresh');
+        await this.authService.revokeToken(refreshToken.token, 'refresh');
       }
       res.status(HttpStatus.OK);
     } catch {} finally {

--- a/src/auth/v2/auth.service.ts
+++ b/src/auth/v2/auth.service.ts
@@ -84,8 +84,7 @@ export class V2AuthService {
     if (!id) {
       return true;
     }
-    await this.redis.del(tokenToId(token));
-    await this.redis.del(TOKEN(id, type));
+    await this.redis.del(tokenToId(token), TOKEN(id, type));
     return true;
   }
   invokeCode(code: string, id: string | bigint) {
@@ -94,7 +93,7 @@ export class V2AuthService {
   }
   async readTokenPairById(id: string) {
     const accessToken = await this.redis.get(TOKEN(id, 'access'));
-    const refreshToken = await this.redis.get(TOKEN(id, 'access'));
+    const refreshToken = await this.redis.get(TOKEN(id, 'refresh'));
     const accessTokenTTL = await this.redis.pttl(TOKEN(id, 'access'));
     const refreshTokenTTL = await this.redis.pttl(TOKEN(id, 'refresh'));
     return {
@@ -142,5 +141,21 @@ export class V2AuthService {
   }
   active(id: string | bigint) {
     return this.redis.exists(TOKEN(id, 'access'));
+  }
+  async kickout(id: string | bigint) {
+    const session = await this.readSessionById(id.toString());
+    if (session) {
+      await this.revokeSession(session);
+    }
+    const { accessToken, refreshToken } = await this.readTokenPairById(
+      id.toString(),
+    );
+    if (accessToken.token) {
+      await this.revokeToken(accessToken.token, 'access');
+    }
+    if (refreshToken.token) {
+      await this.revokeToken(refreshToken.token, 'refresh');
+    }
+    return true;
   }
 }

--- a/src/secure/secure.controller.ts
+++ b/src/secure/secure.controller.ts
@@ -6,12 +6,14 @@ import {
   Patch,
   Post,
   Query,
+  Res,
 } from '@nestjs/common';
 import { SecureService } from './secure.service';
 import { ForgetPassword } from './dto/forget-password';
 import { UpdatePassword } from './dto/update-password';
 import { Account, Auth } from '@app/decorator';
 import { AccountService } from '../account/account.service';
+import { Response } from 'express';
 
 @Controller('secure')
 export class SecureController {
@@ -26,11 +28,17 @@ export class SecureController {
   }
 
   @Patch('/password/forget')
-  async forgetPassword(@Body() body: ForgetPassword) {
+  async forgetPassword(
+    @Res({ passthrough: true }) resp: Response,
+    @Body() body: ForgetPassword,
+  ) {
     return this.secureService
       .forgetPassword(body)
       .then(() => this.secureService.revokeCode('forget', body.email))
-      .then(() => {});
+      .then(() => {
+        resp.clearCookie('session-state');
+        resp.status(HttpStatus.OK);
+      });
   }
 
   @Auth()

--- a/src/secure/secure.service.ts
+++ b/src/secure/secure.service.ts
@@ -11,12 +11,14 @@ import { MailService } from '@app/mail';
 import { ConfigService } from '@app/config';
 import { FORGET_PASSWORD, UPDATE_PASSWORD } from '@app/mail/templates';
 import { Account, Profile } from '@prisma/client';
+import { V2AuthService } from '../auth/v2/auth.service';
 
 @Injectable()
 export class SecureService {
   constructor(
     private auth: AuthService,
     private account: AccountService,
+    private v2Auth: V2AuthService,
     private mail: MailService,
     private config: ConfigService,
     private accountService: AccountService,
@@ -37,7 +39,9 @@ export class SecureService {
     await this.account.updateAccount(account.id, {
       password: data.newPassword,
     });
+    // vv 要兼容 v1
     await this.account.kickout(account.id);
+    await this.v2Auth.kickout(account.id);
     return;
   }
   async forgetPassword(data: ForgetPassword) {


### PR DESCRIPTION
重构了Auth接口, 当前请求流程如下, 携带code请求token时不需要携带clientId.

Token 晋升为全局Token, 所有的clientId共享一个token, 这样可以很轻松的实现全局登出

```mermaid
sequenceDiagram
    Browser ->> Client: 
    Client ->> Browser: 未登录
    Client ->> Browser: 重定向到IDP
    Browser ->> IDP: 
    Browser ->> IDP: 携带表单信息与ClientId请求 /auth/code
    IDP ->> IDP: 检查
    IDP ->> Browser: 返回到Client 携带 code 
    Browser ->> Client: 携带code请求某个接口
    Client ->> IDP: /auth/token?code=xxx
    IDP ->> Client: TokenPair
    Client ->> Client: 局部会话
    Client ->> Browser:局部Token
    Browser ->> Client2: 请求
    Client2 ->> Browser: 返回到IDP
    Browser ->> IDP: 
    IDP ->> IDP: 有session-state
    IDP ->> IDP: 检查 session-state
    IDP ->> IDP: 通过session-state读取 id
    IDP ->> IDP: 通过ID 读取 code
    IDP ->> Browser: 返回 code 重定向到 Client2
    Browser ->> Client2: 请求某个接口 并携带 code
    Client2 ->> IDP: /auth/token?code=xxx
    IDP ->> Client2: 返回Token
    Client2 ->> Client2: 创建局部会话
    Client2 ->> Browser: 返回局部Token
```